### PR TITLE
Listen to original "change" event

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -116,6 +116,8 @@
         // On click, set the clicked one as selected
         selectOptions.on("click", function(e) {
           methods._select($dropdown, $(this));
+          // trigger change event, if declared on the original selector
+          $select.change();
         });
         selectOptions.on("keydown", function(e) {
           if (e.which === 27) {


### PR DESCRIPTION
Trigger change event, if declared on the original selector.

Tested in: Chrome 39.0.2171.71m, Firefox 33.1, IE11
