### PR TITLE
Call attr() instead of prop() to set it to selected

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -305,7 +305,7 @@
 
       // Ss it selected?
       if ($this.prop("selected")) {
-        $option.prop("selected", true);
+        $option.attr("selected", true);
       }
 
       // Append option to our dropdown


### PR DESCRIPTION
Had this issue in Chrome & Meteor, that I couldn't  set an option to selected. This Fix helped.