### PR TITLE
Allow setting $select.val('').change()

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -170,7 +170,6 @@
         // Update dropdown when using val, need to use .val("value").trigger("change");
         $select.on("change", function(e) {
           var $this = $(e.target);
-          if (!$this.val().length) return;
 
           if (!multi) {
             var $selected;


### PR DESCRIPTION
Fixes the issue where user is not able to set the dropdown value to blank programatically
