### PR TITLE
Fix issue in IE for option values with dashes

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -103,10 +103,10 @@
         } else {
             var selectors = [], val = $select.val()
             for (var i in val) {
-              selectors.push('li[value=' + val[i] + ']')
+              selectors.push(val[i]);
             }
             if (selectors.length > 0) {
-              var $target = $dropdown.find(selectors.join(','));
+              var $target = $dropdown.find(function() { return $.inArray($(this).data("value"), selectors) !== -1; });
               $target.removeClass("selected");
               methods._select($dropdown, $target);
             }
@@ -181,7 +181,7 @@
 
         $select.on("DOMNodeRemoved", function(e) {
           var deletedValue = $(e.target).attr('value');
-          $ul.find("li[value='"+deletedValue+"']").remove();
+          $ul.find("li").filter(function() { return $(this).data("value") === deletedValue; }).remove();
           var $selected;
 
           setTimeout(function () {
@@ -210,12 +210,13 @@
             }
             methods._select($dropdown, $selected);
           } else {
-            var target = $select.find(":selected");
+            var target = $select.find(":selected"),
+                values = $(this).val();
             // Unselect all options
             selectOptions.removeClass("selected");
             // Select options
             target.each(function () {
-                var selected = selectOptions.filter("[value=\"" + $(this).attr("value") + "\"]");
+                var selected = selectOptions.filter(function() { return $.inArray($(this).data("value"), values) !== -1; });
                 selected.addClass("selected");
             });
           }
@@ -291,7 +292,7 @@
       });
     },
     select: function(target) {
-      var $target = $(this).find("[value=\"" + target + "\"]");
+      var $target = $(this).find(function() { return $(this).data("value") === target; });
       methods._select($(this), $target);
     },
     _select: function($dropdown, $target) {
@@ -313,17 +314,17 @@
         $target.toggleClass("selected");
         // Toggle selection of the clicked option in native select
         $target.each(function(){
-          var $selected = $select.find("[value=\"" + $(this).attr("value") + "\"]");
+          var $selected = $select.find("[value=\"" + $(this).data("value") + "\"]");
           $selected.prop("selected", $(this).hasClass("selected"));
         });
         // Add or remove the value from the input
         var text = [];
         selectOptions.each(function() {
           if ($(this).hasClass("selected")) {
-            text.push($(this).text());
+            text.push($(this).data("value"));
           }
         });
-        $input.val(text.join(", "));
+        $input.val(text.join(","));
       }
 
       // Behavior for single select
@@ -338,7 +339,7 @@
         // Select the selected option
         $target.addClass("selected");
         // Set the value to the native select
-        $select.val($target.attr("value"));
+        $select.val($target.data("value"));
         // Set the value to the input
         $input.val($target.text().trim());
       }
@@ -354,7 +355,7 @@
 
        // Call the callback
         if (this.options.onSelected) {
-            this.options.onSelected($target.attr("value"));
+            this.options.onSelected($target.data("value"));
         }
 
     },
@@ -374,7 +375,7 @@
         $option.html("&nbsp;");
       }
       // Set the value of the option
-      $option.attr("value", $this.val());
+      $option.data("value", $this.val());
 
       // Will user be able to remove this option?
       if ($ul.data("select").attr("data-dynamic-opts")) {
@@ -419,3 +420,4 @@
   };
 
 }));
+


### PR DESCRIPTION
Currently, there are issues with option lists that have dashes/hyphens in values and IE browsers (11 and Edge).

```
<div class="form-group">
      <select id="special-select" class="form-control">
        <option value="one">One</option>
        <option value="two-three">Two-three</option>
        <option value="4-5">4-5</option>
        <option value="four">Four</option>
        <option value="five">Five</option>
    </select>
</div>
```

When using IE browsers (at least), option "4-5" will not correctly select/save to the hidden form input. and is unable to be set on the underlying select element.

JSBin showing issue (view in IE 11 or Edge and select through the elements)
http://jsbin.com/guvilotoxa/edit?html,js,console,output

This is due to the way the dropdown is constructed.  It reads all the options above, then takes the contents of "value" and sets each &lt;li&gt; "value" to the same.  This is incorrect per the HTML spec as noted in some easier to read spots:
https://developer.mozilla.org/uk/docs/Web/HTML/Element/li

> This integer attribute indicates the current ordinal value of the list item as defined by the &lt;ol&gt; element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The value attribute has no meaning for unordered lists (&lt;ul&gt;) or for menus (&lt;menu&gt;).

https://www.w3schools.com/tags/att_li_value.asp

> The value must be a number and can only be used in ordered lists (&lt;ol&gt;).

These indicate that value must be a number and should only be set for ol, which this plugin is not generating.  I'm proposing here that instead a conversion be made to use data-value, which is safe to use for all values in all browsers.

What appears to happen in IE is that when setting .attr("value"), it will sometimes truncate if the values are numeric and with other values that contain special characters may just not set at all.  This patch fixes this issue and improves compatibility with the HTML spec.