### PR TITLE
remove focus class and blur only on inputs with focus class

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "dropdown.js",
-  "version": "0.0.2dev",
-  "homepage": "https://github.com/FezVrasta/dropdown.js",
+  "name": "dropdown_js",
+  "version": "0.0",
+  "homepage": "https://github.com/bardiainjast/dropdown.js",
   "authors": [
     "Federico Zivolo <info@mywebexpression.com>"
   ],

--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -229,7 +229,7 @@
             return;
           }
           $(".dropdownjs > ul > li").attr("tabindex", -1);
-          $(".dropdownjs > input").not($(this)).removeClass("focus").blur();
+          $(".dropdownjs > input.focus").not($(this)).removeClass("focus").blur();
 
           $(".dropdownjs > ul > li").not(".dropdownjs-add").attr("tabindex", 0);
 


### PR DESCRIPTION
![ezgif com-crop](https://user-images.githubusercontent.com/20615964/31316149-8bcf77ea-ac34-11e7-8cd9-50124841a70e.gif)

hi, i found this issue while using this plugin with redux form, after a while i found that it's bluring inputs which are not focused while the definition of blur says "The blur event is fired when an element has lost focus."
this pull request fixes the issue.